### PR TITLE
Fix and restyle main window

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -6,12 +6,12 @@
     <Application.Resources>
         <!-- Global colour palette -->
         <LinearGradientBrush x:Key="AppBackgroundBrush" StartPoint="0,0" EndPoint="1,1">
-            <GradientStop Color="#9C27B0" Offset="0"/>
-            <GradientStop Color="#E91E63" Offset="1"/>
+            <GradientStop Color="#B666B4" Offset="0"/>
+            <GradientStop Color="#34DB8D" Offset="1"/>
         </LinearGradientBrush>
 
-        <SolidColorBrush x:Key="AccentBrush" Color="#FF69B4"/>
-        <SolidColorBrush x:Key="AccentBrushHover" Color="#FF85C7"/>
+        <SolidColorBrush x:Key="AccentBrush" Color="#FC086F"/>
+        <SolidColorBrush x:Key="AccentBrushHover" Color="#FF5CA2"/>
 
         <!-- Rounded modern button -->
         <Style TargetType="Button">

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,10 +1,9 @@
 <Window x:Class="PomodoroWpf.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Pomodoro" Width="280" Height="280"
+        Title="Pomodoro" Width="300" Height="340"
         WindowStyle="None" AllowsTransparency="True" Background="Transparent"
         ResizeMode="NoResize" WindowStartupLocation="CenterScreen"
-
         FontFamily="Segoe UI" Foreground="White"
         MouseLeftButtonDown="Window_MouseLeftButtonDown">
 
@@ -15,17 +14,12 @@
         </ContextMenu>
     </Window.ContextMenu>
 
-        FontFamily="Segoe UI"
-        Background="{StaticResource AppBackgroundBrush}" Foreground="White">
-
-
-    <Grid>
+    <Grid Background="{StaticResource AppBackgroundBrush}">
         <!-- static background circle -->
-        <Ellipse Width="240" Height="240" Stroke="#FFFFFF40" StrokeThickness="12" 
+        <Ellipse Width="240" Height="240" Stroke="#FFFFFF40" StrokeThickness="12"
                  HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
         <!-- animated progress arc -->
-
         <Path x:Name="ProgressArc" Stroke="{StaticResource AccentBrush}" StrokeThickness="12"
               StrokeStartLineCap="Round" Data="M 0 0"/>
 
@@ -35,29 +29,13 @@
 
         <!-- state label -->
         <TextBlock x:Name="StateText" Text="Ready" FontSize="16"
-                   HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,20"/>
-
-        <!-- Progress ring -->
-        <Grid>
-            <Ellipse Stroke="#FFFFFF40" StrokeThickness="12" />
-            <Path x:Name="ProgressArc"
-                  Stroke="{StaticResource AccentBrush}" StrokeThickness="12" StrokeStartLineCap="Round"
-                  Data="M 0 0"/>
-            <TextBlock x:Name="TimeText" Text="25:00"
-                       FontSize="48" FontWeight="Bold"
-                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            <TextBlock x:Name="StateText" Text="Ready"
-                       FontSize="18" Margin="0,100,0,0"
-                       HorizontalAlignment="Center" VerticalAlignment="Top"/>
-        </Grid>
+                   HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,20,0,0"/>
 
         <!-- Controls -->
-        <StackPanel Orientation="Horizontal" Grid.Row="1" HorizontalAlignment="Center" Margin="0,24,0,0">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,20">
             <Button x:Name="StartPauseBtn" Content="Start" Click="StartPause_Click" Margin="4,0"/>
             <Button Content="Reset" Click="Reset_Click" Margin="4,0"/>
             <Button Content="Settings" Click="Settings_Click" Margin="4,0"/>
         </StackPanel>
-
-
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -58,6 +58,8 @@ namespace PomodoroWpf
                 _isRunning = true;
                 StateText.Text = PhaseLabel();
             }
+
+            StartPauseBtn.Content = _isRunning ? "Pause" : "Start";
         }
 
         private void Reset_Click(object sender, RoutedEventArgs e)
@@ -70,6 +72,7 @@ namespace PomodoroWpf
             UpdateTimeText();
             DrawProgress(0);
             StateText.Text = "Ready";
+            StartPauseBtn.Content = "Start";
         }
 
         private void Settings_Click(object sender, RoutedEventArgs e)
@@ -181,6 +184,11 @@ namespace PomodoroWpf
             {
                 ToggleTimer();
             }
+        }
+
+        private void StartPause_Click(object sender, RoutedEventArgs e)
+        {
+            ToggleTimer();
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix malformed MainWindow.xaml and align timer controls on new gradient background
- implement start/pause button behaviour
- update colour palette to match new design

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689397560e488326b154f1980d8ae4bb